### PR TITLE
chore: update @pulse-editor/cli to version 0.1.26 and improve build p…

### DIFF
--- a/.changeset/lazy-moles-smell.md
+++ b/.changeset/lazy-moles-smell.md
@@ -1,0 +1,6 @@
+---
+"@pulse-editor/shared-utils": patch
+"@pulse-editor/react-api": patch
+---
+
+Update mf version

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -54,6 +54,7 @@
     "kind-peaches-join",
     "large-knives-grow",
     "large-moose-tap",
+    "lazy-moles-smell",
     "lazy-zebras-mate",
     "loud-pandas-obey",
     "mighty-ghosts-crash",

--- a/npm-packages/cli/package-lock.json
+++ b/npm-packages/cli/package-lock.json
@@ -1,24 +1,24 @@
 {
 	"name": "@pulse-editor/cli",
-	"version": "0.1.25",
+	"version": "0.1.26",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@pulse-editor/cli",
-			"version": "0.1.25",
+			"version": "0.1.26",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/enhanced": "2.0.1",
-				"@module-federation/node": "2.7.32",
-				"@module-federation/runtime": "2.0.1",
+				"@module-federation/enhanced": "^2.3.2",
+				"@module-federation/node": "^2.7.40",
+				"@module-federation/runtime": "^2.3.2",
 				"@pulse-editor/shared-utils": "^0.1.1-beta.85",
 				"concurrently": "^9.2.1",
 				"connect-livereload": "^0.6.1",
 				"copy-webpack-plugin": "^14.0.0",
 				"cors": "^2.8.6",
 				"cross-env": "^10.1.0",
-				"dotenv": "^17.3.1",
+				"dotenv": "^17.4.2",
 				"execa": "^9.6.1",
 				"express": "^5.2.1",
 				"glob": "^13.0.6",
@@ -30,12 +30,12 @@
 				"jszip": "^3.10.1",
 				"livereload": "^0.10.3",
 				"meow": "^14.1.0",
-				"mini-css-extract-plugin": "^2.10.0",
-				"openid-client": "^6.8.2",
+				"mini-css-extract-plugin": "^2.10.2",
+				"openid-client": "^6.8.3",
 				"rimraf": "^6.1.3",
-				"ts-morph": "^27.0.2",
+				"ts-morph": "^28.0.0",
 				"tsx": "^4.21.0",
-				"webpack": "^5.105.2",
+				"webpack": "^5.106.1",
 				"webpack-dev-server": "^5.2.3"
 			},
 			"bin": {
@@ -46,14 +46,14 @@
 				"@types/connect-livereload": "^0.6.3",
 				"@types/cors": "^2.8.19",
 				"@types/express": "^5.0.6",
-				"@types/jszip": "^3.4.0",
+				"@types/jszip": "^3.4.1",
 				"@types/livereload": "^0.9.5",
 				"@types/react": "^19.2.14",
 				"@types/react-dom": "^19.2.3",
-				"@vitest/coverage-v8": "^4.1.2",
-				"ava": "^6.4.1",
+				"@vitest/coverage-v8": "^4.1.4",
+				"ava": "^7.0.0",
 				"chalk": "^5.6.2",
-				"eslint-config-xo-react": "^0.29.0",
+				"eslint-config-xo-react": "^0.30.0",
 				"eslint-plugin-react": "^7.37.5",
 				"eslint-plugin-react-hooks": "^7.0.1",
 				"ink-testing-library": "^4.0.0",
@@ -61,8 +61,8 @@
 				"react-dom": "19.2.4",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.9.3",
-				"vitest": "^4.1.2",
-				"xo": "^1.2.3"
+				"vitest": "^4.1.4",
+				"xo": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16"
@@ -907,12 +907,47 @@
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@eslint/compat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.5.tgz",
+			"integrity": "sha512-IbHDbHJfkVNv6xjlET8AIVo/K1NQt7YT4Rp6ok/clyBGcpRx1l6gv0Rq3vBvYfPJIZt6ODf66Zq08FJNDpnzgg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"peerDependencies": {
+				"eslint": "^8.40 || 9 || 10"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@eslint/compat/node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
 		"node_modules/@eslint/config-array": {
 			"version": "0.21.2",
 			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
 			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
@@ -928,6 +963,7 @@
 			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/core": "^0.17.0"
 			},
@@ -948,12 +984,42 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
+		"node_modules/@eslint/css": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/@eslint/css/-/css-0.14.1.tgz",
+			"integrity": "sha512-NXiteSacmpaXqgyIW3+GcNzexXyfC0kd+gig6WTjD4A74kBGJeNx1tV0Hxa0v7x0+mnIyKfGPhGNs1uhRFdh+w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0",
+				"@eslint/css-tree": "^3.6.6",
+				"@eslint/plugin-kit": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/css-tree": {
+			"version": "3.6.9",
+			"resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.6.9.tgz",
+			"integrity": "sha512-3D5/OHibNEGk+wKwNwMbz63NMf367EoR4mVNNpxddCHKEb2Nez7z62J2U6YjtErSsZDoY0CsccmoUpdEbkogNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.23.0",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "3.3.5",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
 			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
@@ -978,11 +1044,55 @@
 			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
+			}
+		},
+		"node_modules/@eslint/json": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/json/-/json-1.2.0.tgz",
+			"integrity": "sha512-CEFEyNgvzu8zn5QwVYDg3FaG+ZKUeUsNYitFpMYJAqoAlnw68EQgNbUfheSmexZr4n0wZPrAkPLuvsLaXO6wRw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.1.1",
+				"@eslint/plugin-kit": "^0.6.1",
+				"@humanwhocodes/momoa": "^3.3.10",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/json/node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/json/node_modules/@eslint/plugin-kit": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.1.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
@@ -991,6 +1101,7 @@
 			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -1047,6 +1158,16 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@humanwhocodes/momoa": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
+			"integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@humanwhocodes/retry": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
@@ -1059,67 +1180,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
-			}
-		},
-		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/@isaacs/fs-minipass": {
@@ -1334,31 +1394,38 @@
 			}
 		},
 		"node_modules/@module-federation/bridge-react-webpack-plugin": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.0.1.tgz",
-			"integrity": "sha512-D7LMW5EMAJShOMR1aZDAJ6s+MdsYDHaQyJADLQ3LaY0sne/BkVqkPikUwcO1IwOwKbXjYsDlQVOEvk9wZVRFhA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.3.2.tgz",
+			"integrity": "sha512-NMzJhTSGz6PpImjbXfpGX595i+N3EFW5RwRgQ2ftTuqT7FS3vqYnC4i/72HNgryYNTSIZZSwjTbfKLyeSTroeA==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/sdk": "2.0.1",
+				"@module-federation/sdk": "2.3.2",
 				"@types/semver": "7.5.8",
 				"semver": "7.6.3"
 			}
 		},
 		"node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
+			},
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@module-federation/cli": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.0.1.tgz",
-			"integrity": "sha512-2SL5Y8iODNX10y9T3CBLhHjSXo4afnA1BK82m4sNfZebuVO+o34bxewqwod9xfWq9xhTZmOSFZ+n+lgTKRv+CQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.3.2.tgz",
+			"integrity": "sha512-dPjNrtcBfwb8vOZVS7YRZZPmLQ00Urv+paYC3882U6AM+hSiOEcv552NLaBCtZt1br5vEmsdYsXqew9KK4urtQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/dts-plugin": "2.0.1",
-				"@module-federation/sdk": "2.0.1",
-				"chalk": "3.0.0",
+				"@module-federation/dts-plugin": "2.3.2",
+				"@module-federation/sdk": "2.3.2",
 				"commander": "11.1.0",
 				"jiti": "2.4.2"
 			},
@@ -1370,60 +1437,27 @@
 			}
 		},
 		"node_modules/@module-federation/cli/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
-		},
-		"node_modules/@module-federation/cli/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
 			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
 			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@module-federation/cli/node_modules/chalk": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@module-federation/cli/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@module-federation/data-prefetch": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.0.1.tgz",
-			"integrity": "sha512-Kq0P1OABGt6QAvs6TaE/zY9Ut9Y/oJFrzoSF3eWaCYbUAr2KD2SpTyMsPz4ssBzjeKXTgimugh6tHHd6mpCBIQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.3.2.tgz",
+			"integrity": "sha512-3NFjBVTEsWyoMNWbYiNu+JmR7TNML9LDrdtZ3ftupMZB5bGa7NTzf299QSvn+5AKrcUdO7Yn7JYG6Y18L86kFQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/runtime": "2.0.1",
-				"@module-federation/sdk": "2.0.1",
-				"fs-extra": "9.1.0"
+				"@module-federation/runtime": "2.3.2",
+				"@module-federation/sdk": "2.3.2"
 			},
 			"peerDependencies": {
 				"react": ">=16.9.0",
@@ -1439,32 +1473,34 @@
 			}
 		},
 		"node_modules/@module-federation/data-prefetch/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
+			},
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@module-federation/dts-plugin": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.0.1.tgz",
-			"integrity": "sha512-PLneTsf1fQS5/RTBedtLAAmCPRdMfIlhfJkOa8QH3WDJaQsqm8Wb3r2cTUBf2aNj/bP3aH/y6Hs9JFB/4x0l5g==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.3.2.tgz",
+			"integrity": "sha512-Egvd6TefTnKfa95u4NlLWnAEWe72NhAYSw4jkXF4WNla0ULbj65XrOIKyk7Lcx7HMCjlvEL7fa218qw8q0EL3Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/error-codes": "2.0.1",
-				"@module-federation/managers": "2.0.1",
-				"@module-federation/sdk": "2.0.1",
-				"@module-federation/third-party-dts-extractor": "2.0.1",
-				"adm-zip": "^0.5.10",
-				"ansi-colors": "^4.1.3",
-				"axios": "^1.12.0",
-				"chalk": "3.0.0",
-				"fs-extra": "9.1.0",
+				"@module-federation/error-codes": "2.3.2",
+				"@module-federation/managers": "2.3.2",
+				"@module-federation/sdk": "2.3.2",
+				"@module-federation/third-party-dts-extractor": "2.3.2",
+				"adm-zip": "0.5.10",
+				"ansi-colors": "4.1.3",
 				"isomorphic-ws": "5.0.0",
-				"koa": "3.0.3",
-				"lodash.clonedeepwith": "4.5.0",
-				"log4js": "6.9.1",
 				"node-schedule": "2.1.1",
-				"rambda": "^9.1.0",
+				"undici": "7.24.7",
 				"ws": "8.18.0"
 			},
 			"peerDependencies": {
@@ -1478,70 +1514,39 @@
 			}
 		},
 		"node_modules/@module-federation/dts-plugin/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
-		},
-		"node_modules/@module-federation/dts-plugin/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
 			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
 			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@module-federation/dts-plugin/node_modules/chalk": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@module-federation/dts-plugin/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@module-federation/enhanced": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.0.1.tgz",
-			"integrity": "sha512-EZIARQ/8ScoTP6PV8+E4SsmMYWK4ErrikZJ0G/FX8wvK8mCtdoKatFtvDN9++P6Nl78kN9zHYgAV4AHKdBVjfQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.3.2.tgz",
+			"integrity": "sha512-MzIL+UO3E3JyoIlTFcKmogqFPQdSJAb3GhRYkl62mHYgG0V49WTPl9tAEIClJ3dp8vIo+FVpMK+r9hG8eShsbg==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/bridge-react-webpack-plugin": "2.0.1",
-				"@module-federation/cli": "2.0.1",
-				"@module-federation/data-prefetch": "2.0.1",
-				"@module-federation/dts-plugin": "2.0.1",
-				"@module-federation/error-codes": "2.0.1",
-				"@module-federation/inject-external-runtime-core-plugin": "2.0.1",
-				"@module-federation/managers": "2.0.1",
-				"@module-federation/manifest": "2.0.1",
-				"@module-federation/rspack": "2.0.1",
-				"@module-federation/runtime-tools": "2.0.1",
-				"@module-federation/sdk": "2.0.1",
-				"btoa": "^1.2.1",
-				"schema-utils": "^4.3.0",
+				"@module-federation/bridge-react-webpack-plugin": "2.3.2",
+				"@module-federation/cli": "2.3.2",
+				"@module-federation/data-prefetch": "2.3.2",
+				"@module-federation/dts-plugin": "2.3.2",
+				"@module-federation/error-codes": "2.3.2",
+				"@module-federation/inject-external-runtime-core-plugin": "2.3.2",
+				"@module-federation/managers": "2.3.2",
+				"@module-federation/manifest": "2.3.2",
+				"@module-federation/rspack": "2.3.2",
+				"@module-federation/runtime-tools": "2.3.2",
+				"@module-federation/sdk": "2.3.2",
+				"@module-federation/webpack-bundler-runtime": "2.3.2",
+				"schema-utils": "4.3.0",
+				"tapable": "2.3.0",
 				"upath": "2.0.1"
 			},
 			"bin": {
@@ -1565,134 +1570,170 @@
 			}
 		},
 		"node_modules/@module-federation/enhanced/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.0.1.tgz",
-			"integrity": "sha512-oAA7G+4GCHM+WRYfscR/x4GwCyM9CEqfdD9/x2L6y8mtLWK9anRLKTocsI759AvzXsbT1m3EQ5ki1O6wlwDu3g==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.3.2.tgz",
+			"integrity": "sha512-RoQtwJZE2Y/nu44rzRVLUDtA1EYaoXY4rdxM6vdYTZA4mZWMYtfn1fBbOIrOaiqmH5t1te7hTr5Nu7PW1gLhwQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@module-federation/runtime-tools": "2.0.1"
+				"@module-federation/runtime-tools": "2.3.2"
 			}
 		},
 		"node_modules/@module-federation/enhanced/node_modules/@module-federation/runtime-tools": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.0.1.tgz",
-			"integrity": "sha512-AStdwBtsGB3jIfDg9oP+KyVPsimdaeHsP855gqCxDp1hi2+GKjlZWZx9ThkS8NytVSXSUysxqoUL1ivDoKgcCQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.2.tgz",
+			"integrity": "sha512-i9B3h2PgEjXMj9slEQdzus58t6UsTRGAaAB+E2fN7cOIKii4t0+bkChFFLtqplUvWMH6/AQ1D4Gj2IfwlbOXDg==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/runtime": "2.0.1",
-				"@module-federation/webpack-bundler-runtime": "2.0.1"
+				"@module-federation/runtime": "2.3.2",
+				"@module-federation/webpack-bundler-runtime": "2.3.2"
 			}
 		},
 		"node_modules/@module-federation/enhanced/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
+			},
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@module-federation/enhanced/node_modules/@module-federation/webpack-bundler-runtime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.0.1.tgz",
-			"integrity": "sha512-u1NId3SF4lHDTmD2CHFEszulmXmIq1TGw9JYvnLx5rKJL7xt3aNxcb1GvkaYbRNVBXhSMjJ75E5LsQlZzyBx9A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.2.tgz",
+			"integrity": "sha512-K9XRr7Jhsmo2JjETwIctLi+R22mUjtSZ5hUEgvwcHeGss8enqdDU+kt2NP/SVG+/dRUXkvzkGppqkjd6sBKg7w==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/runtime": "2.0.1",
-				"@module-federation/sdk": "2.0.1"
+				"@module-federation/error-codes": "2.3.2",
+				"@module-federation/runtime": "2.3.2",
+				"@module-federation/sdk": "2.3.2"
+			}
+		},
+		"node_modules/@module-federation/enhanced/node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@module-federation/enhanced/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/@module-federation/enhanced/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/@module-federation/enhanced/node_modules/schema-utils": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/@module-federation/error-codes": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.0.1.tgz",
-			"integrity": "sha512-2bJF/ft+qL9L6Zvq2t/G9/f/0wFL73cM8/NJ04uyYz9BjIgvx28K5qu8/6+IwgEEKATG7vOhBBVj6wH3S+5ASA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.2.tgz",
+			"integrity": "sha512-Y8F6EG+shNY5mJ0yKcJh4t6HlMYEtqMvABDDmxWulLz/tSV859SL05I5eDR1EvK0jNhLbq8LFipFEToQLqF0AA==",
 			"license": "MIT"
 		},
 		"node_modules/@module-federation/managers": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.0.1.tgz",
-			"integrity": "sha512-KR01lSlcYRQ9C6hW2a8CQQtAE0LvfTLgtV/6ZNUTagw8sRfeDln+ggrZsYilKu9zl0i8RPDgpv/kS60o4lcxCQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.3.2.tgz",
+			"integrity": "sha512-mb8NfwLDZbA08HXkEjsAXyqyIyR+FC73tZxCHlPW/3fdTB5WLKG9Qrq/uan/zq/uyTdtYT3MCaMh7uf3ezqFMQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/sdk": "2.0.1",
-				"find-pkg": "2.0.0",
-				"fs-extra": "9.1.0"
+				"@module-federation/sdk": "2.3.2",
+				"find-pkg": "2.0.0"
 			}
 		},
 		"node_modules/@module-federation/managers/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
+			},
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@module-federation/manifest": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.0.1.tgz",
-			"integrity": "sha512-p8nYGjHWp17MsYdW/Vv0ogBDiTTsI1PHWPQbvVIqLQXDqwiesaRSRR1zziECXQoEL8lV5Bs+uSkcaJGhea9P+A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.3.2.tgz",
+			"integrity": "sha512-yzYgN1H5zNE7SbdeGXZ29NsZygDtQTsyWpIX42gLZfg2V9POqrNgxvaZUjYUV07c8m+ecZHcylHGHFuKHacfZA==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/dts-plugin": "2.0.1",
-				"@module-federation/managers": "2.0.1",
-				"@module-federation/sdk": "2.0.1",
-				"chalk": "3.0.0",
+				"@module-federation/dts-plugin": "2.3.2",
+				"@module-federation/managers": "2.3.2",
+				"@module-federation/sdk": "2.3.2",
 				"find-pkg": "2.0.0"
 			}
 		},
 		"node_modules/@module-federation/manifest/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
-		},
-		"node_modules/@module-federation/manifest/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
 			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
 			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@module-federation/manifest/node_modules/chalk": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@module-federation/manifest/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@module-federation/node": {
-			"version": "2.7.32",
-			"resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.32.tgz",
-			"integrity": "sha512-hUj5v2GGwpNzl2gaJS4AyzCYRzJBhN8875A+ucKF9tq3jaQb5zpy3izYMISqqbN2q9a7jz3nEUgwAh3pjri+rQ==",
+			"version": "2.7.40",
+			"resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.40.tgz",
+			"integrity": "sha512-Q5y3L5Toy5s1bzb/bGjgg8/kKUbQAi5RCRRcsJFjUFKvSqehizB5WXFiL+xtjYmUt3ltZ4FWc+75Uqk+tSo9iQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/enhanced": "2.0.1",
-				"@module-federation/runtime": "2.0.1",
-				"@module-federation/sdk": "2.0.1",
-				"btoa": "1.2.1",
-				"encoding": "^0.1.13",
-				"node-fetch": "2.7.0"
+				"@module-federation/enhanced": "2.3.2",
+				"@module-federation/runtime": "2.3.2",
+				"@module-federation/sdk": "2.3.2",
+				"encoding": "0.1.13",
+				"node-fetch": "2.7.0",
+				"tapable": "2.3.0"
 			},
 			"peerDependencies": {
 				"webpack": "^5.40.0"
@@ -1704,25 +1745,32 @@
 			}
 		},
 		"node_modules/@module-federation/node/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
+			},
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@module-federation/rspack": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.0.1.tgz",
-			"integrity": "sha512-SAlNE8iclFmzrKtx3/C2GivXYx6nPzx4MgQV01QG/a4LpnLbwlxzdZu3rqQ2swp4NNWT/t/GT7Y+7gfhyVa7mg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.3.2.tgz",
+			"integrity": "sha512-16nG7y5x8Gi5UjGYrx69hR2Eh92MTK76slzieCs9/kVBoCmI8KS9YFELSyo5NM+CMOoSKFnauNsH28dNLsV2Wg==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/bridge-react-webpack-plugin": "2.0.1",
-				"@module-federation/dts-plugin": "2.0.1",
-				"@module-federation/inject-external-runtime-core-plugin": "2.0.1",
-				"@module-federation/managers": "2.0.1",
-				"@module-federation/manifest": "2.0.1",
-				"@module-federation/runtime-tools": "2.0.1",
-				"@module-federation/sdk": "2.0.1",
-				"btoa": "1.2.1"
+				"@module-federation/bridge-react-webpack-plugin": "2.3.2",
+				"@module-federation/dts-plugin": "2.3.2",
+				"@module-federation/inject-external-runtime-core-plugin": "2.3.2",
+				"@module-federation/managers": "2.3.2",
+				"@module-federation/manifest": "2.3.2",
+				"@module-federation/runtime-tools": "2.3.2",
+				"@module-federation/sdk": "2.3.2"
 			},
 			"peerDependencies": {
 				"@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
@@ -1739,66 +1787,83 @@
 			}
 		},
 		"node_modules/@module-federation/rspack/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.0.1.tgz",
-			"integrity": "sha512-oAA7G+4GCHM+WRYfscR/x4GwCyM9CEqfdD9/x2L6y8mtLWK9anRLKTocsI759AvzXsbT1m3EQ5ki1O6wlwDu3g==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.3.2.tgz",
+			"integrity": "sha512-RoQtwJZE2Y/nu44rzRVLUDtA1EYaoXY4rdxM6vdYTZA4mZWMYtfn1fBbOIrOaiqmH5t1te7hTr5Nu7PW1gLhwQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@module-federation/runtime-tools": "2.0.1"
+				"@module-federation/runtime-tools": "2.3.2"
 			}
 		},
 		"node_modules/@module-federation/rspack/node_modules/@module-federation/runtime-tools": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.0.1.tgz",
-			"integrity": "sha512-AStdwBtsGB3jIfDg9oP+KyVPsimdaeHsP855gqCxDp1hi2+GKjlZWZx9ThkS8NytVSXSUysxqoUL1ivDoKgcCQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.2.tgz",
+			"integrity": "sha512-i9B3h2PgEjXMj9slEQdzus58t6UsTRGAaAB+E2fN7cOIKii4t0+bkChFFLtqplUvWMH6/AQ1D4Gj2IfwlbOXDg==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/runtime": "2.0.1",
-				"@module-federation/webpack-bundler-runtime": "2.0.1"
+				"@module-federation/runtime": "2.3.2",
+				"@module-federation/webpack-bundler-runtime": "2.3.2"
 			}
 		},
 		"node_modules/@module-federation/rspack/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
+			},
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@module-federation/rspack/node_modules/@module-federation/webpack-bundler-runtime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.0.1.tgz",
-			"integrity": "sha512-u1NId3SF4lHDTmD2CHFEszulmXmIq1TGw9JYvnLx5rKJL7xt3aNxcb1GvkaYbRNVBXhSMjJ75E5LsQlZzyBx9A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.2.tgz",
+			"integrity": "sha512-K9XRr7Jhsmo2JjETwIctLi+R22mUjtSZ5hUEgvwcHeGss8enqdDU+kt2NP/SVG+/dRUXkvzkGppqkjd6sBKg7w==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/runtime": "2.0.1",
-				"@module-federation/sdk": "2.0.1"
+				"@module-federation/error-codes": "2.3.2",
+				"@module-federation/runtime": "2.3.2",
+				"@module-federation/sdk": "2.3.2"
 			}
 		},
 		"node_modules/@module-federation/runtime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.0.1.tgz",
-			"integrity": "sha512-UQ72P5Oo40dS6vdhHetwTtIsbGciEr+bjoYvDgh1WLPfFlTYd8zo9cLfqaf3juuPfV3cMVARAVPmh16lQYpUGA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.2.tgz",
+			"integrity": "sha512-JFSAbr0zBDmNF+wcqHw22CmZGuUZjTsa4qzm1+RUVi3blrnKeBj9Y2FppEOBwPc/FHUr4/MDijA/6GFE2cv7gQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/error-codes": "2.0.1",
-				"@module-federation/runtime-core": "2.0.1",
-				"@module-federation/sdk": "2.0.1"
+				"@module-federation/error-codes": "2.3.2",
+				"@module-federation/runtime-core": "2.3.2",
+				"@module-federation/sdk": "2.3.2"
 			}
 		},
 		"node_modules/@module-federation/runtime-core": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.0.1.tgz",
-			"integrity": "sha512-gOuCPSHoQGUGwlxfSTMInFX+QvLxdEWegGGMiLdU5vqbXuva4E9M+kXBBO7/0MkcBPMmVs0wOJGm0XOLeV2f1Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.2.tgz",
+			"integrity": "sha512-o4Pfi21uADHtSl3/BHu/3ph5+069pDOXL8Lck12b+rxsHessbeZkNo+MOxwP+gXf8fFsT+f9spOmx+Y5gtyc2A==",
 			"license": "MIT",
 			"dependencies": {
-				"@module-federation/error-codes": "2.0.1",
-				"@module-federation/sdk": "2.0.1"
+				"@module-federation/error-codes": "2.3.2",
+				"@module-federation/sdk": "2.3.2"
 			}
 		},
 		"node_modules/@module-federation/runtime-core/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
+			},
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@module-federation/runtime-tools": {
 			"version": "0.21.6",
@@ -1842,10 +1907,18 @@
 			}
 		},
 		"node_modules/@module-federation/runtime/node_modules/@module-federation/sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-			"integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-			"license": "MIT"
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+			"integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"node-fetch": "^3.3.2"
+			},
+			"peerDependenciesMeta": {
+				"node-fetch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@module-federation/sdk": {
 			"version": "0.21.6",
@@ -1855,13 +1928,12 @@
 			"peer": true
 		},
 		"node_modules/@module-federation/third-party-dts-extractor": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.0.1.tgz",
-			"integrity": "sha512-neKSr6FNUeGRh+YR57l/QZUzPytJXuJx+babF7j5iGJG3FP+kfizr6QD0hgVis5KEoXMVbQ8yyvG0slERizeyw==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.3.2.tgz",
+			"integrity": "sha512-aQmzd7KPkk39LuOh9us2XxXdMmaGLfTU6fJEEsvjzRIgwQtQ10BRAnuJ+GGW1BkD9tXtbuYtW4+bWT7JxX4Pyg==",
 			"license": "MIT",
 			"dependencies": {
 				"find-pkg": "2.0.0",
-				"fs-extra": "9.1.0",
 				"resolve": "1.22.8"
 			}
 		},
@@ -2138,17 +2210,6 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@pkgr/core": {
@@ -2544,29 +2605,30 @@
 			"license": "MIT"
 		},
 		"node_modules/@stylistic/eslint-plugin": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.4.1.tgz",
-			"integrity": "sha512-CEigAk7eOLyHvdgmpZsKFwtiqS2wFwI1fn4j09IU9GmD4euFM4jEBAViWeCqaNLlbX2k2+A/Fq9cje4HQBXuJQ==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+			"integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "^8.32.1",
-				"eslint-visitor-keys": "^4.2.0",
-				"espree": "^10.3.0",
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/types": "^8.56.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
 				"estraverse": "^5.3.0",
-				"picomatch": "^4.0.2"
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"peerDependencies": {
-				"eslint": ">=9.0.0"
+				"eslint": "^9.0.0 || ^10.0.0"
 			}
 		},
 		"node_modules/@ts-morph/common": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
-			"integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+			"version": "0.29.0",
+			"resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.29.0.tgz",
+			"integrity": "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==",
 			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^10.0.1",
@@ -2596,12 +2658,12 @@
 			}
 		},
 		"node_modules/@ts-morph/common/node_modules/minimatch": {
-			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -2745,6 +2807,13 @@
 				"@types/estree": "*"
 			}
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2802,9 +2871,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/jszip": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.0.tgz",
-			"integrity": "sha512-GFHqtQQP3R4NNuvZH3hNCYD0NbyBZ42bkN7kO3NDrU/SnvIZWMS8Bp38XCsRKBT5BXvgm0y1zqpZWp/ZkRzBzg==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.1.tgz",
+			"integrity": "sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==",
+			"deprecated": "This is a stub types definition. jszip provides its own type definitions, so you do not need this installed.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2927,20 +2997,20 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-			"integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+			"integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.56.1",
-				"@typescript-eslint/type-utils": "8.56.1",
-				"@typescript-eslint/utils": "8.56.1",
-				"@typescript-eslint/visitor-keys": "8.56.1",
+				"@typescript-eslint/scope-manager": "8.58.2",
+				"@typescript-eslint/type-utils": "8.58.2",
+				"@typescript-eslint/utils": "8.58.2",
+				"@typescript-eslint/visitor-keys": "8.58.2",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.4.0"
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2950,9 +3020,9 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.56.1",
+				"@typescript-eslint/parser": "^8.58.2",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -2966,16 +3036,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-			"integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+			"integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.56.1",
-				"@typescript-eslint/types": "8.56.1",
-				"@typescript-eslint/typescript-estree": "8.56.1",
-				"@typescript-eslint/visitor-keys": "8.56.1",
+				"@typescript-eslint/scope-manager": "8.58.2",
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/typescript-estree": "8.58.2",
+				"@typescript-eslint/visitor-keys": "8.58.2",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2987,18 +3057,18 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-			"integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+			"integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.56.1",
-				"@typescript-eslint/types": "^8.56.1",
+				"@typescript-eslint/tsconfig-utils": "^8.58.2",
+				"@typescript-eslint/types": "^8.58.2",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -3009,18 +3079,18 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-			"integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+			"integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.56.1",
-				"@typescript-eslint/visitor-keys": "8.56.1"
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/visitor-keys": "8.58.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3031,9 +3101,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-			"integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+			"integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3044,21 +3114,21 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-			"integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+			"integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.56.1",
-				"@typescript-eslint/typescript-estree": "8.56.1",
-				"@typescript-eslint/utils": "8.56.1",
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/typescript-estree": "8.58.2",
+				"@typescript-eslint/utils": "8.58.2",
 				"debug": "^4.4.3",
-				"ts-api-utils": "^2.4.0"
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3069,13 +3139,13 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-			"integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+			"integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3087,21 +3157,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-			"integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+			"integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.56.1",
-				"@typescript-eslint/tsconfig-utils": "8.56.1",
-				"@typescript-eslint/types": "8.56.1",
-				"@typescript-eslint/visitor-keys": "8.56.1",
+				"@typescript-eslint/project-service": "8.58.2",
+				"@typescript-eslint/tsconfig-utils": "8.58.2",
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/visitor-keys": "8.58.2",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
 				"tinyglobby": "^0.2.15",
-				"ts-api-utils": "^2.4.0"
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3111,7 +3181,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
@@ -3138,13 +3208,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -3167,16 +3237,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-			"integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+			"integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.56.1",
-				"@typescript-eslint/types": "8.56.1",
-				"@typescript-eslint/typescript-estree": "8.56.1"
+				"@typescript-eslint/scope-manager": "8.58.2",
+				"@typescript-eslint/types": "8.58.2",
+				"@typescript-eslint/typescript-estree": "8.58.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3187,17 +3257,17 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-			"integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+			"integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.56.1",
+				"@typescript-eslint/types": "8.58.2",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -3504,9 +3574,9 @@
 			]
 		},
 		"node_modules/@vercel/nft": {
-			"version": "0.29.4",
-			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.29.4.tgz",
-			"integrity": "sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.5.0.tgz",
+			"integrity": "sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3517,7 +3587,7 @@
 				"async-sema": "^3.1.1",
 				"bindings": "^1.4.0",
 				"estree-walker": "2.0.2",
-				"glob": "^10.4.5",
+				"glob": "^13.0.0",
 				"graceful-fs": "^4.2.9",
 				"node-gyp-build": "^4.2.2",
 				"picomatch": "^4.0.2",
@@ -3527,89 +3597,18 @@
 				"nft": "out/cli.js"
 			},
 			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vercel/nft/node_modules/brace-expansion": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@vercel/nft/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@vercel/nft/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@vercel/nft/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@vercel/nft/node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
-			"integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+			"integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/utils": "4.1.4",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -3623,8 +3622,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.2",
-				"vitest": "4.1.2"
+				"@vitest/browser": "4.1.4",
+				"vitest": "4.1.4"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -3633,16 +3632,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-			"integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+			"integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -3651,13 +3650,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-			"integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+			"integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.2",
+				"@vitest/spy": "4.1.4",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -3688,9 +3687,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-			"integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+			"integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3701,13 +3700,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-			"integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+			"integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.2",
+				"@vitest/utils": "4.1.4",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -3715,14 +3714,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-			"integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+			"integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/utils": "4.1.4",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -3731,9 +3730,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-			"integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+			"integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -3741,13 +3740,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-			"integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+			"integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.2",
+				"@vitest/pretty-format": "4.1.4",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -3937,9 +3936,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -3981,9 +3980,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3994,12 +3993,12 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"version": "0.5.10",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+			"integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=12.0"
+				"node": ">=6.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -4414,21 +4413,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"license": "MIT"
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/auto-bind": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
@@ -4442,58 +4426,57 @@
 			}
 		},
 		"node_modules/ava": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-6.4.1.tgz",
-			"integrity": "sha512-vxmPbi1gZx9zhAjHBgw81w/iEDKcrokeRk/fqDTyA2DQygZ0o+dUGRHFOtX8RA5N0heGJTTsIk7+xYxitDb61Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-7.0.0.tgz",
+			"integrity": "sha512-4sRJO/gehlfAgSbuH02mClDDiyymnuFmirE3KqPXl2pic1FaFTZaAACKqr85WT4o08iLjViMR9gmMkxzbZ3AgA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vercel/nft": "^0.29.4",
-				"acorn": "^8.15.0",
-				"acorn-walk": "^8.3.4",
-				"ansi-styles": "^6.2.1",
+				"@vercel/nft": "^1.3.2",
+				"acorn": "^8.16.0",
+				"acorn-walk": "^8.3.5",
+				"ansi-styles": "^6.2.3",
 				"arrgv": "^1.0.2",
 				"arrify": "^3.0.0",
 				"callsites": "^4.2.0",
-				"cbor": "^10.0.9",
-				"chalk": "^5.4.1",
+				"cbor": "^10.0.11",
+				"chalk": "^5.6.2",
 				"chunkd": "^2.0.1",
-				"ci-info": "^4.3.0",
+				"ci-info": "^4.4.0",
 				"ci-parallel-vars": "^1.0.1",
-				"cli-truncate": "^4.0.0",
+				"cli-truncate": "^5.1.1",
 				"code-excerpt": "^4.0.0",
 				"common-path-prefix": "^3.0.0",
 				"concordance": "^5.0.4",
 				"currently-unhandled": "^0.4.1",
-				"debug": "^4.4.1",
+				"debug": "^4.4.3",
 				"emittery": "^1.2.0",
 				"figures": "^6.1.0",
-				"globby": "^14.1.0",
+				"globby": "^16.1.1",
 				"ignore-by-default": "^2.1.0",
 				"indent-string": "^5.0.0",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
-				"matcher": "^5.0.0",
-				"memoize": "^10.1.0",
+				"matcher": "^6.0.0",
+				"memoize": "^10.2.0",
 				"ms": "^2.1.3",
-				"p-map": "^7.0.3",
+				"p-map": "^7.0.4",
 				"package-config": "^5.0.0",
-				"picomatch": "^4.0.2",
-				"plur": "^5.1.0",
-				"pretty-ms": "^9.2.0",
+				"picomatch": "^4.0.3",
+				"plur": "^6.0.0",
+				"pretty-ms": "^9.3.0",
 				"resolve-cwd": "^3.0.0",
 				"stack-utils": "^2.0.6",
-				"strip-ansi": "^7.1.0",
 				"supertap": "^3.0.1",
 				"temp-dir": "^3.0.0",
-				"write-file-atomic": "^6.0.0",
-				"yargs": "^17.7.2"
+				"write-file-atomic": "^7.0.0",
+				"yargs": "^18.0.0"
 			},
 			"bin": {
 				"ava": "entrypoints/cli.mjs"
 			},
 			"engines": {
-				"node": "^18.18 || ^20.8 || ^22 || ^23 || >=24"
+				"node": "^20.19 || ^22.20 || ^24.12 || >=25"
 			},
 			"peerDependencies": {
 				"@ava/typescript": "*"
@@ -4502,6 +4485,49 @@
 				"@ava/typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/ava/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/ava/node_modules/yargs": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^7.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/ava/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"node_modules/available-typed-arrays": {
@@ -4518,17 +4544,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/axios": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-			"license": "MIT",
-			"dependencies": {
-				"follow-redirects": "^1.15.11",
-				"form-data": "^4.0.5",
-				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -4694,18 +4709,6 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
-		"node_modules/btoa": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-			"integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-			"license": "(MIT OR Apache-2.0)",
-			"bin": {
-				"btoa": "bin/btoa.js"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4713,9 +4716,9 @@
 			"license": "MIT"
 		},
 		"node_modules/builtin-modules": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
-			"integrity": "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.1.0.tgz",
+			"integrity": "sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4884,6 +4887,13 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/change-case": {
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+			"integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -4926,9 +4936,9 @@
 			"license": "MIT"
 		},
 		"node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -5023,17 +5033,32 @@
 			}
 		},
 		"node_modules/cli-truncate": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-			"integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
-			"dev": true,
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+			"integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
 			"license": "MIT",
 			"dependencies": {
-				"slice-ansi": "^5.0.0",
-				"string-width": "^7.0.0"
+				"slice-ansi": "^8.0.0",
+				"string-width": "^8.2.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/string-width": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+			"integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5176,18 +5201,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"license": "MIT"
-		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"license": "MIT",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/commander": {
 			"version": "11.1.0",
@@ -5454,19 +5467,6 @@
 				"node": ">=6.6.0"
 			}
 		},
-		"node_modules/cookies": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
-			"integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
-			"license": "MIT",
-			"dependencies": {
-				"depd": "~2.0.0",
-				"keygrip": "~1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/copy-webpack-plugin": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
@@ -5491,13 +5491,13 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
-			"integrity": "sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+			"integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.0"
+				"browserslist": "^4.28.1"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5706,15 +5706,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/date-format": {
-			"version": "4.0.14",
-			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
-			"integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/date-time": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
@@ -5744,12 +5735,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/deep-equal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
-			"license": "MIT"
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
@@ -5833,21 +5818,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-			"license": "MIT"
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",
@@ -5994,9 +5964,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.3.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-			"integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
@@ -6018,13 +5988,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
@@ -6089,9 +6052,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.19.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-			"integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+			"integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -6292,6 +6255,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -6419,6 +6383,7 @@
 			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6505,31 +6470,10 @@
 				"eslint": ">=7.0.0"
 			}
 		},
-		"node_modules/eslint-config-xo": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.46.0.tgz",
-			"integrity": "sha512-mjQUhdTCLQwHUFKf1hhSx1FFhm2jllr4uG2KjaW7gZHGAbjKoSypvo1eQvFk17lHx3bztYjZDDXQmkAZyaSlAg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@stylistic/eslint-plugin": "^2.6.1",
-				"confusing-browser-globals": "1.0.11",
-				"globals": "^15.3.0"
-			},
-			"engines": {
-				"node": ">=18.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			},
-			"peerDependencies": {
-				"eslint": ">=9.8.0"
-			}
-		},
 		"node_modules/eslint-config-xo-react": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo-react/-/eslint-config-xo-react-0.29.0.tgz",
-			"integrity": "sha512-OiA3fnGu5tkQkcFhXV1J9ZTUr25DDVoGpBdA2dowH6rNZFDed+WtxzcoUNwQNFXqWRAjsFjuxAzw3c1iAHom0Q==",
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo-react/-/eslint-config-xo-react-0.30.0.tgz",
+			"integrity": "sha512-jOHxOsQmaoBTF5vp4+Eu3TaTsUAp/XWnnhfrCTtNwznmEB41WaR6G/7eezxf+8AOW5lMrafUnFvmgae3LPQ+LA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6546,96 +6490,21 @@
 				"eslint": ">=9.18.0"
 			}
 		},
-		"node_modules/eslint-config-xo-typescript": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-7.0.0.tgz",
-			"integrity": "sha512-Mvy5eo6PW2BWPpxLsG7Y28LciZhLhiXFZAw/H3kdia34Efudk2aWMWwAKqkEFamo/SHiyMYkqUx6DYO+YJeVVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@stylistic/eslint-plugin": "^2.6.1",
-				"eslint-config-xo": "^0.46.0",
-				"typescript-eslint": "^8.3.0"
-			},
-			"engines": {
-				"node": ">=18.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			},
-			"peerDependencies": {
-				"eslint": ">=9.8.0",
-				"typescript": ">=5.5.0"
-			}
-		},
-		"node_modules/eslint-config-xo-typescript/node_modules/@stylistic/eslint-plugin": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
-			"integrity": "sha512-RnO1SaiCFHn666wNz2QfZEFxvmiNRqhzaMXHXxXXKt+MEP7aajlPxUSMIQpKAaJfverpovEYqjBOXDq6dDcaOQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/utils": "^8.13.0",
-				"eslint-visitor-keys": "^4.2.0",
-				"espree": "^10.3.0",
-				"estraverse": "^5.3.0",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"peerDependencies": {
-				"eslint": ">=8.40.0"
-			}
-		},
-		"node_modules/eslint-config-xo/node_modules/@stylistic/eslint-plugin": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
-			"integrity": "sha512-RnO1SaiCFHn666wNz2QfZEFxvmiNRqhzaMXHXxXXKt+MEP7aajlPxUSMIQpKAaJfverpovEYqjBOXDq6dDcaOQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/utils": "^8.13.0",
-				"eslint-visitor-keys": "^4.2.0",
-				"espree": "^10.3.0",
-				"estraverse": "^5.3.0",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"peerDependencies": {
-				"eslint": ">=8.40.0"
-			}
-		},
-		"node_modules/eslint-config-xo/node_modules/globals": {
-			"version": "15.15.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-			"integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/eslint-formatter-pretty": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-6.0.1.tgz",
-			"integrity": "sha512-znAUcXmBthdIUmlnRkPSxz3zSJHFUhfHF/nJPcCMVKg/mOa4yUie2Olqg1Ghbi5JJRBZVU3rIgzWSObvIspxMA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-7.1.0.tgz",
+			"integrity": "sha512-iyPrgpwKC3MMM75Wxn0VouD89HolpG+BL95NOxgwOWO0R+Omapo7gFX2xcGVsUDS7KiXLtDuynLbNbOARSE7YA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/eslint": "^8.44.6",
-				"ansi-escapes": "^6.2.0",
-				"chalk": "^5.3.0",
+				"@types/eslint": "^9.6.1",
+				"ansi-escapes": "^7.1.0",
+				"chalk": "^5.6.2",
 				"eslint-rule-docs": "^1.1.235",
-				"log-symbols": "^6.0.0",
+				"log-symbols": "^7.0.1",
 				"plur": "^5.1.0",
-				"string-width": "^7.0.0",
-				"supports-hyperlinks": "^3.0.0"
+				"string-width": "^8.1.0",
+				"supports-hyperlinks": "^4.3.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -6644,25 +6513,44 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint-formatter-pretty/node_modules/@types/eslint": {
-			"version": "8.56.12",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
-			"integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "*",
-				"@types/json-schema": "*"
-			}
-		},
-		"node_modules/eslint-formatter-pretty/node_modules/ansi-escapes": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
-			"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+		"node_modules/eslint-formatter-pretty/node_modules/irregular-plurals": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+			"integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/plur": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
+			"integrity": "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"irregular-plurals": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-formatter-pretty/node_modules/string-width": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+			"integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6691,60 +6579,6 @@
 				"unrs-resolver": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/eslint-plugin-ava": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-15.1.0.tgz",
-			"integrity": "sha512-+6Zxk1uYW3mf7lxCLWIQsFYgn3hfuCMbsKc0MtqfloOz1F6fiV5/PaWEaLgkL1egrSQmnyR7vOFP1wSPJbVUbw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"enhance-visitors": "^1.0.0",
-				"eslint-utils": "^3.0.0",
-				"espree": "^9.0.0",
-				"espurify": "^2.1.1",
-				"import-modules": "^2.1.0",
-				"micro-spelling-correcter": "^1.1.1",
-				"pkg-dir": "^5.0.0",
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.18 || >=20"
-			},
-			"peerDependencies": {
-				"eslint": ">=9"
-			}
-		},
-		"node_modules/eslint-plugin-ava/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-ava/node_modules/espree": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"acorn": "^8.9.0",
-				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-plugin-es-x": {
@@ -6860,9 +6694,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n": {
-			"version": "17.23.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.23.1.tgz",
-			"integrity": "sha512-68PealUpYoHOBh332JLLD9Sj7OQUDkFpmcfqt8R9sySfFSeuGJjMTJQvCRRB96zO3A/PELRLkPrzsHmzEFQQ5A==",
+			"version": "17.24.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
+			"integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6899,34 +6733,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint-plugin-no-use-extend-native": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.7.2.tgz",
-			"integrity": "sha512-hUBlwaTXIO1GzTwPT6pAjvYwmSHe4XduDhAiQvur4RUujmBUFjd8Nb2+e7WQdsQ+nGHWGRlogcUWXJRGqizTWw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-get-set-prop": "^2.0.0",
-				"is-js-type": "^3.0.0",
-				"is-obj-prop": "^2.0.0",
-				"is-proto-prop": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=18.18.0"
-			},
-			"peerDependencies": {
-				"eslint": "^9.3.0"
-			}
-		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-			"integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.11.7"
+				"prettier-linter-helpers": "^1.0.1",
+				"synckit": "^0.11.12"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -6947,25 +6762,6 @@
 				"eslint-config-prettier": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/eslint-plugin-promise": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.2.1.tgz",
-			"integrity": "sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-react": {
@@ -7050,65 +6846,37 @@
 			}
 		},
 		"node_modules/eslint-plugin-unicorn": {
-			"version": "59.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-59.0.1.tgz",
-			"integrity": "sha512-EtNXYuWPUmkgSU2E7Ttn57LbRREQesIP1BiLn7OZLKodopKfDXfBUkC/0j6mpw2JExwf43Uf3qLSvrSvppgy8Q==",
+			"version": "63.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-63.0.0.tgz",
+			"integrity": "sha512-Iqecl9118uQEXYh7adylgEmGfkn5es3/mlQTLLkd4pXkIk9CTGrAbeUux+YljSa2ohXCBmQQ0+Ej1kZaFgcfkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.25.9",
-				"@eslint-community/eslint-utils": "^4.5.1",
-				"@eslint/plugin-kit": "^0.2.7",
-				"ci-info": "^4.2.0",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@eslint-community/eslint-utils": "^4.9.0",
+				"change-case": "^5.4.4",
+				"ci-info": "^4.3.1",
 				"clean-regexp": "^1.0.0",
-				"core-js-compat": "^3.41.0",
-				"esquery": "^1.6.0",
+				"core-js-compat": "^3.46.0",
 				"find-up-simple": "^1.0.1",
-				"globals": "^16.0.0",
+				"globals": "^16.4.0",
 				"indent-string": "^5.0.0",
 				"is-builtin-module": "^5.0.0",
 				"jsesc": "^3.1.0",
 				"pluralize": "^8.0.0",
 				"regexp-tree": "^0.1.27",
-				"regjsparser": "^0.12.0",
-				"semver": "^7.7.1",
-				"strip-indent": "^4.0.0"
+				"regjsparser": "^0.13.0",
+				"semver": "^7.7.3",
+				"strip-indent": "^4.1.1"
 			},
 			"engines": {
-				"node": "^18.20.0 || ^20.10.0 || >=21.0.0"
+				"node": "^20.10.0 || >=21.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
 			},
 			"peerDependencies": {
-				"eslint": ">=9.22.0"
-			}
-		},
-		"node_modules/eslint-plugin-unicorn/node_modules/@eslint/core": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-			"integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@types/json-schema": "^7.0.15"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/eslint-plugin-unicorn/node_modules/@eslint/plugin-kit": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-			"integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@eslint/core": "^0.13.0",
-				"levn": "^0.4.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"eslint": ">=9.38.0"
 			}
 		},
 		"node_modules/eslint-plugin-unicorn/node_modules/globals": {
@@ -7125,9 +6893,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-unicorn/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7150,6 +6918,7 @@
 			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -7159,35 +6928,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
-			}
-		},
-		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
@@ -7209,6 +6949,7 @@
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -7225,6 +6966,7 @@
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -7242,6 +6984,7 @@
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -7282,16 +7025,16 @@
 			}
 		},
 		"node_modules/espurify": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
-			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-3.2.0.tgz",
+			"integrity": "sha512-+jfGpC1eUu7s4M8sXnnoUsQfEQ1qqkEr/S+V47QR+GC/NODe98s4iPYq/2KrNaS1guTjHBhMS4j9N3NOObT1WQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -7528,9 +7271,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7739,12 +7482,13 @@
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
 			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.11",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"funding": [
 				{
 					"type": "individual",
@@ -7777,60 +7521,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/foreground-child": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/form-data/node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/form-data/node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/forwarded": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7847,21 +7537,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-			"license": "MIT",
-			"dependencies": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/fsevents": {
@@ -7996,24 +7671,14 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/get-set-props": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.2.0.tgz",
-			"integrity": "sha512-YCmOj+4YAeEB5Dd9jfp6ETdejMet4zSxXjNkgaa4npBEKRI9uDOGB5MmAdAgi2OoFGAKshYhCbmLq2DS03CgVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/get-stdin": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
-			"integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-10.0.0.tgz",
+			"integrity": "sha512-eWSePJ4zXFdqz+/Lyfopob4rIcoF/U2XfE8nJc7iZV6lnebWc9k7DoQQpX+2a9jc0AOvBsXvbe5YkjXl/MHbpg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8054,9 +7719,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+			"version": "4.13.8",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.8.tgz",
+			"integrity": "sha512-J87BxkLXykmisLQ+KA4x2+O6rVf+PJrtFUO8lGyiRg4lyxJLJ8/v0sRAKdVZQOy6tR6lMRAF1NqzCf9BQijm0w==",
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -8200,6 +7865,7 @@
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -8225,34 +7891,21 @@
 			}
 		},
 		"node_modules/globby": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+			"integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sindresorhus/merge-streams": "^2.1.0",
+				"@sindresorhus/merge-streams": "^4.0.0",
 				"fast-glob": "^3.3.3",
-				"ignore": "^7.0.3",
-				"path-type": "^6.0.0",
+				"ignore": "^7.0.5",
+				"is-path-inside": "^4.0.0",
 				"slash": "^5.1.0",
-				"unicorn-magic": "^0.3.0"
+				"unicorn-magic": "^0.4.0"
 			},
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/globby/node_modules/@sindresorhus/merge-streams": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8266,6 +7919,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/globby/node_modules/unicorn-magic": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+			"integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/globrex": {
@@ -8366,6 +8032,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -8563,53 +8230,6 @@
 				"entities": "^2.0.0"
 			}
 		},
-		"node_modules/http-assert": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
-			"integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
-			"license": "MIT",
-			"dependencies": {
-				"deep-equal": "~1.0.1",
-				"http-errors": "~1.8.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/http-assert/node_modules/depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/http-assert/node_modules/http-errors": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-			"license": "MIT",
-			"dependencies": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/http-assert/node_modules/statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/http-deceiver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -8751,19 +8371,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/import-modules": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
-			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/imurmurhash": {
@@ -8917,59 +8524,11 @@
 				"react": ">=18"
 			}
 		},
-		"node_modules/ink/node_modules/cli-truncate": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-			"integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
-			"license": "MIT",
-			"dependencies": {
-				"slice-ansi": "^7.1.0",
-				"string-width": "^8.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ink/node_modules/cli-truncate/node_modules/slice-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-			"integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"is-fullwidth-code-point": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
 		"node_modules/ink/node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"license": "ISC"
-		},
-		"node_modules/ink/node_modules/slice-ansi": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
-			"integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.3",
-				"is-fullwidth-code-point": "^5.1.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
 		},
 		"node_modules/ink/node_modules/string-width": {
 			"version": "8.2.0",
@@ -9027,13 +8586,16 @@
 			}
 		},
 		"node_modules/irregular-plurals": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
-			"integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-4.2.0.tgz",
+			"integrity": "sha512-bW9UXHL7bnUcNtTo+9ccSngbxc+V40H32IgvdVin0Xs8gbo+AVYD5g/72ce/54Kjfhq66vcZr8H8TKEvsifeOw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -9280,20 +8842,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-get-set-prop": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-2.0.0.tgz",
-			"integrity": "sha512-C32bqXfHJfRwa0U5UIMqSGziZhALszXDJZ8n8mz8WZ6c6V7oYGHEWwJvftliBswypY3P3EQqdY5lpDSEKvTS1Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"get-set-props": "^0.2.0",
-				"lowercase-keys": "^3.0.0"
-			},
-			"engines": {
-				"node": "> 18.0.0"
-			}
-		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -9321,6 +8869,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-in-ssh": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+			"integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-inside-container": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -9337,19 +8898,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-js-type": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-3.0.0.tgz",
-			"integrity": "sha512-IbPf3g3vxm1D902xaBaYp2TUHiXZWwWRu5bM9hgKN9oAQcFaKALV6Gd13PGhXjKE5u2n8s1PhLhdke/E1fchxQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"js-types": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/is-map": {
@@ -9416,18 +8964,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-obj-prop": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-2.0.0.tgz",
-			"integrity": "sha512-2/VFrbzXSZVJIscazpxoB+pOQx2jBOAAL9Gui4cRKxflznUNBpsr8IDvBA4UGol3e40sltLNiY3qnZv/7qSUxA==",
+		"node_modules/is-path-inside": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"lowercase-keys": "^3.0.0",
-				"obj-props": "^2.0.0"
-			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -9457,20 +9004,6 @@
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"license": "MIT"
-		},
-		"node_modules/is-proto-prop": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-proto-prop/-/is-proto-prop-3.0.1.tgz",
-			"integrity": "sha512-S8xSxNMGJO4eZD86kO46zrq2gLIhA+rN9443lQEvt8Mz/l8cxk72p/AWFmofY6uL9g9ILD6cXW6j8QQj4F3Hcw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lowercase-keys": "^3.0.0",
-				"prototype-properties": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
 		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
@@ -9757,22 +9290,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
 		"node_modules/jest-worker": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -9797,9 +9314,9 @@
 			}
 		},
 		"node_modules/jose": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-			"integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+			"integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -9821,19 +9338,6 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/js-types": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-types/-/js-types-4.0.0.tgz",
-			"integrity": "sha512-/c+n06zvqFQGxdz1BbElF7S3nEghjNchLN1TjQnk2j10HYDaUc57rcvl6BbnziTx8NQmrg0JOs/iwRpvcYaxjQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.1",
@@ -9901,18 +9405,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
 		"node_modules/jsx-ast-utils": {
 			"version": "3.3.5",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -9977,18 +9469,6 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"node_modules/keygrip": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-			"integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-			"license": "MIT",
-			"dependencies": {
-				"tsscmp": "1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -9997,105 +9477,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
-			}
-		},
-		"node_modules/koa": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/koa/-/koa-3.0.3.tgz",
-			"integrity": "sha512-MeuwbCoN1daWS32/Ni5qkzmrOtQO2qrnfdxDHjrm6s4b59yG4nexAJ0pTEFyzjLp0pBVO80CZp0vW8Ze30Ebow==",
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "^1.3.8",
-				"content-disposition": "~0.5.4",
-				"content-type": "^1.0.5",
-				"cookies": "~0.9.1",
-				"delegates": "^1.0.0",
-				"destroy": "^1.2.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"fresh": "~0.5.2",
-				"http-assert": "^1.5.0",
-				"http-errors": "^2.0.0",
-				"koa-compose": "^4.1.0",
-				"mime-types": "^3.0.1",
-				"on-finished": "^2.4.1",
-				"parseurl": "^1.3.3",
-				"statuses": "^2.0.1",
-				"type-is": "^2.0.1",
-				"vary": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/koa-compose": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
-			"integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-			"license": "MIT"
-		},
-		"node_modules/koa/node_modules/accepts": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-types": "~2.1.34",
-				"negotiator": "0.6.3"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/koa/node_modules/accepts/node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/koa/node_modules/content-disposition": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/koa/node_modules/fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/koa/node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/koa/node_modules/negotiator": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/launch-editor": {
@@ -10393,29 +9774,29 @@
 			}
 		},
 		"node_modules/line-column-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/line-column-path/-/line-column-path-3.0.0.tgz",
-			"integrity": "sha512-Atocnm7Wr9nuvAn97yEPQa3pcQI5eLQGBz+m6iTb+CVw+IOzYB9MrYK7jI7BfC9ISnT4Fu0eiwhAScV//rp4Hw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/line-column-path/-/line-column-path-4.0.0.tgz",
+			"integrity": "sha512-Zvpvd56i9FRV5kaJFiiY1t+FNMEH+dGEaLyQprqKlGHBAxJXmdSk+8tVsh6b9YlxbfyyuLrhJCkzwB+AmOBZ0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"type-fest": "^2.0.0"
+				"unicorn-magic": "^0.4.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/line-column-path/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+		"node_modules/line-column-path/node_modules/unicorn-magic": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+			"integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
 			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
+			"license": "MIT",
 			"engines": {
-				"node": ">=12.20"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -10500,63 +9881,29 @@
 			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
-		"node_modules/lodash.clonedeepwith": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-			"integrity": "sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==",
-			"license": "MIT"
-		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/log-symbols": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+			"integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^5.3.0",
-				"is-unicode-supported": "^1.3.0"
+				"is-unicode-supported": "^2.0.0",
+				"yoctocolors": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-symbols/node_modules/is-unicode-supported": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log4js": {
-			"version": "6.9.1",
-			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
-			"integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"date-format": "^4.0.14",
-				"debug": "^4.3.4",
-				"flatted": "^3.2.7",
-				"rfdc": "^1.3.0",
-				"streamroller": "^3.1.5"
-			},
-			"engines": {
-				"node": ">=8.0"
 			}
 		},
 		"node_modules/long-timeout": {
@@ -10585,19 +9932,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/lowercase-keys": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-			"integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -10665,16 +9999,16 @@
 			"license": "ISC"
 		},
 		"node_modules/matcher": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/matcher/-/matcher-5.0.0.tgz",
-			"integrity": "sha512-s2EMBOWtXFc8dgqvoAzKJXxNHibcdJMV0gwqKUaw9E2JBJuGUK7DrNKrA6g/i+v72TT16+6sVm5mS3thaMLQUw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-6.0.0.tgz",
+			"integrity": "sha512-TzDerdcNtI79w7Av4GT57bLdElPA/VAkjqdMZv8yhuc8geU2z0ljW9anXbX/55aHEMTpYypZb1lxsA/46r9oOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"escape-string-regexp": "^5.0.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -10714,6 +10048,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.23.0.tgz",
+			"integrity": "sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/media-typer": {
 			"version": "1.1.0",
@@ -10899,9 +10240,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.0.tgz",
-			"integrity": "sha512-540P2c5dYnJlyJxTaSloliZexv8rji6rY8FhQN+WF/82iHQfA23j/xtJx97L+mXOML27EqksSek/g4eK7jaL3g==",
+			"version": "2.10.2",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+			"integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
 			"license": "MIT",
 			"dependencies": {
 				"schema-utils": "^4.0.0",
@@ -11181,16 +10522,6 @@
 				"url": "https://github.com/sponsors/panva"
 			}
 		},
-		"node_modules/obj-props": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/obj-props/-/obj-props-2.0.0.tgz",
-			"integrity": "sha512-Q/uLAAfjdhrzQWN2czRNh3fDCgXjh7yRIkdHjDgIHTwpFP0BsshxTA3HRNffHR7Iw/XGTH30u8vdMXQ+079urA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -11378,32 +10709,70 @@
 			}
 		},
 		"node_modules/open-editor": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-5.1.0.tgz",
-			"integrity": "sha512-KkNqM6FdoegD6WhY2YXmWcovOux45NV+zBped2+G3+V74zkDPkIl4cqh6hte2zNDojtwO2nBOV8U+sgziWfPrg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-6.0.0.tgz",
+			"integrity": "sha512-LGd2Xn6NvFlbx/lg/HK69w6Dbg+21MzJzcPDPQRgDRqc+qiR+2/SN99rzZSo7Qa1ck1hcGYig0CAo53cmXCE0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"env-editor": "^1.1.0",
-				"execa": "^9.3.0",
-				"line-column-path": "^3.0.0",
-				"open": "^10.1.0"
+				"env-editor": "^1.3.0",
+				"execa": "^9.6.0",
+				"line-column-path": "^4.0.0",
+				"open": "^11.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/open": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+			"integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.4.0",
+				"define-lazy-prop": "^3.0.0",
+				"is-in-ssh": "^1.0.0",
+				"is-inside-container": "^1.0.0",
+				"powershell-utils": "^0.1.0",
+				"wsl-utils": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open-editor/node_modules/wsl-utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+			"integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0",
+				"powershell-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/openid-client": {
-			"version": "6.8.2",
-			"resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.2.tgz",
-			"integrity": "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==",
+			"version": "6.8.3",
+			"resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.3.tgz",
+			"integrity": "sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA==",
 			"license": "MIT",
 			"dependencies": {
-				"jose": "^6.1.3",
-				"oauth4webapi": "^3.8.4"
+				"jose": "^6.2.2",
+				"oauth4webapi": "^3.8.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -11709,19 +11078,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/path-type": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -11747,19 +11103,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pkg-dir": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/pkijs": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.3.3.tgz",
@@ -11778,16 +11121,16 @@
 			}
 		},
 		"node_modules/plur": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
-			"integrity": "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-6.0.0.tgz",
+			"integrity": "sha512-Y9wXQivjRX0REtwpA9+n0bYYypWESn3cWtW2vazymw711qn+AQXxzZjRqhANYGBLIMC1UzVdpwe/1hHQwHfwng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"irregular-plurals": "^3.3.0"
+				"irregular-plurals": "^4.2.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -11814,9 +11157,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+			"integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
 			"dev": true,
 			"funding": [
 				{
@@ -11842,6 +11185,19 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/powershell-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+			"integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11853,9 +11209,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+			"integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -11869,9 +11225,9 @@
 			}
 		},
 		"node_modules/prettier-linter-helpers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+			"integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11924,19 +11280,6 @@
 				"react-is": "^16.13.1"
 			}
 		},
-		"node_modules/prototype-properties": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/prototype-properties/-/prototype-properties-5.0.0.tgz",
-			"integrity": "sha512-uCWE2QqnGlwvvJXTwiHTPTyHE62+zORO5hpFWhAwBGDtEtTmNZZleNLJDoFsqHCL4p/CeAP2Q1uMKFUKALuRGQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -11948,15 +11291,6 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/proxy-from-env": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/punycode": {
@@ -12021,12 +11355,6 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT"
-		},
-		"node_modules/rambda": {
-			"version": "9.4.2",
-			"resolved": "https://registry.npmjs.org/rambda/-/rambda-9.4.2.tgz",
-			"integrity": "sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==",
 			"license": "MIT"
 		},
 		"node_modules/range-parser": {
@@ -12201,29 +11529,16 @@
 			}
 		},
 		"node_modules/regjsparser": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
-			"integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+			"integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"jsesc": "~3.0.2"
+				"jsesc": "~3.1.0"
 			},
 			"bin": {
 				"regjsparser": "bin/parser"
-			}
-		},
-		"node_modules/regjsparser/node_modules/jsesc": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"jsesc": "bin/jsesc"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/relateurl": {
@@ -12396,12 +11711,6 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/rfdc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-			"license": "MIT"
 		},
 		"node_modules/rimraf": {
 			"version": "6.1.3",
@@ -13083,33 +12392,19 @@
 			}
 		},
 		"node_modules/slice-ansi": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-			"integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-			"dev": true,
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+			"integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.0.0",
-				"is-fullwidth-code-point": "^4.0.0"
+				"ansi-styles": "^6.2.3",
+				"is-fullwidth-code-point": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-			"integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/sockjs": {
@@ -13263,52 +12558,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/streamroller": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
-			"integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
-			"license": "MIT",
-			"dependencies": {
-				"date-format": "^4.0.14",
-				"debug": "^4.3.4",
-				"fs-extra": "^8.1.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
-		"node_modules/streamroller/node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
-		"node_modules/streamroller/node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"license": "MIT",
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/streamroller/node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -13333,62 +12582,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/string.prototype.matchall": {
@@ -13504,30 +12697,6 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-final-newline": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -13559,6 +12728,7 @@
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -13622,33 +12792,46 @@
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+			"integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
+				"has-flag": "^5.0.1",
+				"supports-color": "^10.2.2"
 			},
 			"engines": {
-				"node": ">=14.18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
 			}
 		},
-		"node_modules/supports-hyperlinks/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+		"node_modules/supports-hyperlinks/node_modules/has-flag": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+			"integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/supports-hyperlinks/node_modules/supports-color": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+			"integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -13664,9 +12847,9 @@
 			}
 		},
 		"node_modules/synckit": {
-			"version": "0.11.11",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13705,9 +12888,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.12",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.12.tgz",
-			"integrity": "sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+			"integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -13850,9 +13033,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13950,9 +13133,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-			"integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13986,12 +13169,12 @@
 			}
 		},
 		"node_modules/ts-morph": {
-			"version": "27.0.2",
-			"resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
-			"integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-28.0.0.tgz",
+			"integrity": "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==",
 			"license": "MIT",
 			"dependencies": {
-				"@ts-morph/common": "~0.28.1",
+				"@ts-morph/common": "~0.29.0",
 				"code-block-writer": "^13.0.3"
 			}
 		},
@@ -14044,15 +13227,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
-		},
-		"node_modules/tsscmp": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-			"integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6.x"
-			}
 		},
 		"node_modules/tsx": {
 			"version": "4.21.0",
@@ -14222,16 +13396,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.56.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
-			"integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+			"version": "8.58.2",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+			"integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.56.1",
-				"@typescript-eslint/parser": "8.56.1",
-				"@typescript-eslint/typescript-estree": "8.56.1",
-				"@typescript-eslint/utils": "8.56.1"
+				"@typescript-eslint/eslint-plugin": "8.58.2",
+				"@typescript-eslint/parser": "8.58.2",
+				"@typescript-eslint/typescript-estree": "8.58.2",
+				"@typescript-eslint/utils": "8.58.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -14242,7 +13416,7 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -14264,6 +13438,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/undici": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+			"integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -14280,15 +13463,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/unpipe": {
@@ -14510,19 +13684,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-			"integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+			"integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.2",
-				"@vitest/mocker": "4.1.2",
-				"@vitest/pretty-format": "4.1.2",
-				"@vitest/runner": "4.1.2",
-				"@vitest/snapshot": "4.1.2",
-				"@vitest/spy": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/expect": "4.1.4",
+				"@vitest/mocker": "4.1.4",
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/runner": "4.1.4",
+				"@vitest/snapshot": "4.1.4",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -14550,10 +13724,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.2",
-				"@vitest/browser-preview": "4.1.2",
-				"@vitest/browser-webdriverio": "4.1.2",
-				"@vitest/ui": "4.1.2",
+				"@vitest/browser-playwright": "4.1.4",
+				"@vitest/browser-preview": "4.1.4",
+				"@vitest/browser-webdriverio": "4.1.4",
+				"@vitest/coverage-istanbul": "4.1.4",
+				"@vitest/coverage-v8": "4.1.4",
+				"@vitest/ui": "4.1.4",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -14575,6 +13751,12 @@
 					"optional": true
 				},
 				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
 					"optional": true
 				},
 				"@vitest/ui": {
@@ -14620,9 +13802,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/webpack": {
-			"version": "5.105.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
-			"integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+			"version": "5.106.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.1.tgz",
+			"integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
@@ -14631,11 +13813,11 @@
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.19.0",
+				"enhanced-resolve": "^5.20.0",
 				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -14647,9 +13829,9 @@
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.3.16",
+				"terser-webpack-plugin": "^5.3.17",
 				"watchpack": "^2.5.1",
-				"webpack-sources": "^3.3.3"
+				"webpack-sources": "^3.3.4"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -15180,9 +14362,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
@@ -15453,96 +14635,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -15550,17 +14642,16 @@
 			"license": "ISC"
 		},
 		"node_modules/write-file-atomic": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
-			"integrity": "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+			"integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"imurmurhash": "^0.1.4",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/ws": {
@@ -15600,76 +14691,228 @@
 			}
 		},
 		"node_modules/xo": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-1.2.3.tgz",
-			"integrity": "sha512-ykvWr88620CwealQwr7nWcPwolE6RMAVsCSBIdF3JnVdQUBAllnBJypSPsu0YYFzWTrJjQfNgH82lnWMPVTXnA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-2.0.2.tgz",
+			"integrity": "sha512-08L33hcKMksZyUAK7P8f6Hx5oiEgmya2NjgidvH2e3mBjot9kHz5vlxBjUPX5nparSgxBre/+xVPicat8P2WLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
-				"@sindresorhus/tsconfig": "^7.0.0",
-				"@stylistic/eslint-plugin": "^4.2.0",
-				"@typescript-eslint/parser": "^8.37.0",
+				"@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
+				"@eslint/compat": "^2.0.2",
+				"@sindresorhus/tsconfig": "^8.1.0",
 				"arrify": "^3.0.0",
 				"cosmiconfig": "^9.0.0",
 				"define-lazy-prop": "^3.0.0",
-				"eslint": "^9.31.0",
-				"eslint-config-prettier": "^10.1.5",
-				"eslint-config-xo-react": "^0.28.0",
-				"eslint-config-xo-typescript": "^7.0.0",
-				"eslint-formatter-pretty": "^6.0.1",
-				"eslint-plugin-ava": "^15.0.1",
+				"eslint": "^10.0.2",
+				"eslint-config-prettier": "^10.1.8",
+				"eslint-config-xo-react": "^0.29.0",
+				"eslint-config-xo-typescript": "^10.0.0",
+				"eslint-formatter-pretty": "^7.0.0",
+				"eslint-plugin-ava": "^16.0.0",
 				"eslint-plugin-import-x": "^4.16.1",
-				"eslint-plugin-n": "^17.21.0",
-				"eslint-plugin-no-use-extend-native": "^0.7.2",
-				"eslint-plugin-prettier": "^5.5.1",
-				"eslint-plugin-promise": "^7.2.1",
-				"eslint-plugin-unicorn": "^59.0.1",
+				"eslint-plugin-n": "^17.24.0",
+				"eslint-plugin-prettier": "^5.5.5",
+				"eslint-plugin-unicorn": "^63.0.0",
 				"find-cache-directory": "^6.0.0",
-				"get-stdin": "^9.0.0",
-				"get-tsconfig": "^4.10.1",
-				"globals": "^16.3.0",
-				"globby": "^14.1.0",
-				"meow": "^13.2.0",
+				"get-stdin": "^10.0.0",
+				"get-tsconfig": "^4.13.6",
+				"globals": "^17.3.0",
+				"globby": "^16.1.1",
+				"meow": "^14.1.0",
 				"micromatch": "^4.0.8",
-				"open-editor": "^5.1.0",
+				"open-editor": "^6.0.0",
 				"path-exists": "^5.0.0",
-				"prettier": "^3.6.2",
-				"type-fest": "^4.41.0",
-				"typescript-eslint": "^8.37.0"
+				"prettier": "^3.8.1",
+				"type-fest": "^5.4.3",
+				"typescript": "^5.9.3",
+				"typescript-eslint": "^8.56.1"
 			},
 			"bin": {
 				"xo": "dist/cli.js"
 			},
 			"engines": {
-				"node": ">=20.17"
+				"node": ">=20.19"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/@sindresorhus/tsconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-7.0.0.tgz",
-			"integrity": "sha512-i5K04hLAP44Af16zmDjG07E1NHuDgCM07SJAT4gY0LZSRrWYzwt4qkLem6TIbIVh0k51RkN2bF+lP+lM5eC9fw==",
+		"node_modules/xo/node_modules/@eslint/config-array": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^3.0.5",
+				"debug": "^4.3.1",
+				"minimatch": "^10.2.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/xo/node_modules/@eslint/config-helpers": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+			"integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/xo/node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/xo/node_modules/@eslint/object-schema": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/xo/node_modules/@eslint/plugin-kit": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/xo/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": "18 || 20 || >=22"
 			}
 		},
-		"node_modules/xo/node_modules/eslint-config-xo-react": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo-react/-/eslint-config-xo-react-0.28.0.tgz",
-			"integrity": "sha512-dKvxB9kxMNLhWKsh6yiptACet+/WwKcN7ID2hIBAmjH6le4tt8um4sJ0/aAH6y+xle9tPrasX1Wnz90muCoz9A==",
+		"node_modules/xo/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"eslint-plugin-react": "^7.37.4",
-				"eslint-plugin-react-hooks": "^5.1.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/xo/node_modules/eslint": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+			"integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.4",
+				"@eslint/config-helpers": "^0.5.4",
+				"@eslint/core": "^1.2.0",
+				"@eslint/plugin-kit": "^0.7.0",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"minimatch": "^10.2.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xo/node_modules/eslint-config-xo": {
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.50.0.tgz",
+			"integrity": "sha512-IC+G7r8cIZkspJX5Ug97Si3aHyLatx+eZ5w/dyLuBo0HDZj13uIsZy+mlbXM18aN2/MLarIn0vq4R/a75Gmfcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint/css": "^0.14.1",
+				"@eslint/json": "^1.0.0",
+				"@stylistic/eslint-plugin": "^5.7.1",
+				"confusing-browser-globals": "1.0.11",
+				"globals": "^17.3.0"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			},
+			"peerDependencies": {
+				"eslint": ">=10"
+			}
+		},
+		"node_modules/xo/node_modules/eslint-config-xo-react": {
+			"version": "0.29.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo-react/-/eslint-config-xo-react-0.29.0.tgz",
+			"integrity": "sha512-OiA3fnGu5tkQkcFhXV1J9ZTUr25DDVoGpBdA2dowH6rNZFDed+WtxzcoUNwQNFXqWRAjsFjuxAzw3c1iAHom0Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-plugin-react": "^7.37.5",
+				"eslint-plugin-react-hooks": "^7.0.1"
 			},
 			"engines": {
 				"node": ">=18.18"
@@ -15681,23 +14924,104 @@
 				"eslint": ">=9.18.0"
 			}
 		},
-		"node_modules/xo/node_modules/eslint-plugin-react-hooks": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-			"integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+		"node_modules/xo/node_modules/eslint-config-xo-typescript": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-10.0.0.tgz",
+			"integrity": "sha512-WoyK93F9WCoEv4teY+Ah6PttfS+ckRkpTeasWJ/VYD5IfONzAx9muRrn3VQXf0zUJUEPGrujz02ghgGKdpsTfw==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@stylistic/eslint-plugin": "^5.10.0",
+				"eslint-config-xo": "^0.50.0",
+				"typescript-eslint": "^8.57.0"
+			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=20.19"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			},
 			"peerDependencies": {
-				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+				"eslint": ">=10",
+				"typescript": ">=5.9.0"
+			}
+		},
+		"node_modules/xo/node_modules/eslint-plugin-ava": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-16.0.1.tgz",
+			"integrity": "sha512-1QsYwUulr9m9o6EFndkI0J10wZyVimmrQ1epB8zEowulW0o8fW/ahIHrPwTMT53AWbObD+8S78Uz9aKM3zS9+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@eslint/json": "^1.0.0",
+				"enhance-visitors": "^1.0.0",
+				"espree": "^11.1.0",
+				"espurify": "^3.2.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"peerDependencies": {
+				"eslint": ">=10"
+			}
+		},
+		"node_modules/xo/node_modules/eslint-scope": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/xo/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/xo/node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/xo/node_modules/globals": {
-			"version": "16.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"version": "17.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+			"integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15707,17 +15031,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/meow": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+		"node_modules/xo/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
-			"license": "MIT",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
 			"engines": {
-				"node": ">=18"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/xo/node_modules/path-exists": {
@@ -15728,6 +15055,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/xo/node_modules/type-fest": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+			"integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/y18n": {

--- a/npm-packages/cli/package.json
+++ b/npm-packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pulse-editor/cli",
-	"version": "0.1.25",
+	"version": "0.1.26",
 	"license": "MIT",
 	"bin": {
 		"pulse": "dist/cli.js"
@@ -15,22 +15,22 @@
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",
 		"link": "npm link",
-		"pack": "npm run build && npm pack --pack-destination dist"
+		"pack": "rimraf dist && npm run build && npm pack --pack-destination dist"
 	},
 	"files": [
 		"dist"
 	],
 	"dependencies": {
-		"@module-federation/enhanced": "2.0.1",
-		"@module-federation/node": "2.7.32",
-		"@module-federation/runtime": "2.0.1",
+		"@module-federation/enhanced": "^2.3.2",
+		"@module-federation/node": "^2.7.40",
+		"@module-federation/runtime": "^2.3.2",
 		"@pulse-editor/shared-utils": "^0.1.1-beta.85",
 		"concurrently": "^9.2.1",
 		"connect-livereload": "^0.6.1",
 		"copy-webpack-plugin": "^14.0.0",
 		"cors": "^2.8.6",
 		"cross-env": "^10.1.0",
-		"dotenv": "^17.3.1",
+		"dotenv": "^17.4.2",
 		"execa": "^9.6.1",
 		"express": "^5.2.1",
 		"glob": "^13.0.6",
@@ -42,12 +42,12 @@
 		"jszip": "^3.10.1",
 		"livereload": "^0.10.3",
 		"meow": "^14.1.0",
-		"mini-css-extract-plugin": "^2.10.0",
-		"openid-client": "^6.8.2",
+		"mini-css-extract-plugin": "^2.10.2",
+		"openid-client": "^6.8.3",
 		"rimraf": "^6.1.3",
-		"ts-morph": "^27.0.2",
+		"ts-morph": "^28.0.0",
 		"tsx": "^4.21.0",
-		"webpack": "^5.105.2",
+		"webpack": "^5.106.1",
 		"webpack-dev-server": "^5.2.3"
 	},
 	"devDependencies": {
@@ -55,14 +55,14 @@
 		"@types/connect-livereload": "^0.6.3",
 		"@types/cors": "^2.8.19",
 		"@types/express": "^5.0.6",
-		"@types/jszip": "^3.4.0",
+		"@types/jszip": "^3.4.1",
 		"@types/livereload": "^0.9.5",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
-		"@vitest/coverage-v8": "^4.1.2",
-		"ava": "^6.4.1",
+		"@vitest/coverage-v8": "^4.1.4",
+		"ava": "^7.0.0",
 		"chalk": "^5.6.2",
-		"eslint-config-xo-react": "^0.29.0",
+		"eslint-config-xo-react": "^0.30.0",
 		"eslint-plugin-react": "^7.37.5",
 		"eslint-plugin-react-hooks": "^7.0.1",
 		"ink-testing-library": "^4.0.0",
@@ -70,8 +70,8 @@
 		"react-dom": "19.2.4",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.9.3",
-		"vitest": "^4.1.2",
-		"xo": "^1.2.3"
+		"vitest": "^4.1.4",
+		"xo": "^2.0.2"
 	},
 	"peerDependencies": {
 		"react": "19.2.4",

--- a/npm-packages/cli/src/lib/webpack/configs/mf-server.ts
+++ b/npm-packages/cli/src/lib/webpack/configs/mf-server.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import mfNode from "@module-federation/node";
+import { createRequire } from "node:module";
+import { NodeFederationPlugin } from "@module-federation/node";
 import fs from "fs";
 import path from "path";
+
+const require = createRequire(import.meta.url);
 import wp, { Compiler, Configuration as WebpackConfig } from "webpack";
 import {
   compileAppActionSkills,
@@ -10,7 +13,6 @@ import {
   loadPulseConfig,
 } from "./utils.js";
 
-const { NodeFederationPlugin } = mfNode;
 const { webpack } = wp;
 
 class MFServerPlugin {
@@ -51,50 +53,55 @@ class MFServerPlugin {
       });
 
       // When a file changes and triggers a new compilation
-      compiler.hooks.watchRun.tapPromise("ReloadMessagePlugin", async (compiler) => {
-        this.printChanges(compiler);
+      compiler.hooks.watchRun.tapPromise(
+        "ReloadMessagePlugin",
+        async (compiler) => {
+          this.printChanges(compiler);
 
-        if (!isFirstRun) {
-          console.log(`[Server] 🔄 Reloading app...`);
-          const isServerFunctionChange = compiler.modifiedFiles
-            ? Array.from(compiler.modifiedFiles).some((file) =>
-                file.includes("src/server-function"),
-              )
-            : false;
+          if (!isFirstRun) {
+            console.log(`[Server] 🔄 Reloading app...`);
+            const isServerFunctionChange = compiler.modifiedFiles
+              ? Array.from(compiler.modifiedFiles).some((file) =>
+                  file.includes("src/server-function"),
+                )
+              : false;
 
-          if (isServerFunctionChange) {
+            if (isServerFunctionChange) {
+              await this.compileServerFunctions(compiler);
+            }
+
+            const isActionChange = compiler.modifiedFiles
+              ? Array.from(compiler.modifiedFiles).some((file) =>
+                  file.includes("src/skill"),
+                )
+              : false;
+
+            if (isActionChange) {
+              console.log(
+                `[Server] Detected changes in actions. Recompiling...`,
+              );
+              this.pulseConfig = compileAppActionSkills(this.pulseConfig);
+              this.saveConfig();
+            }
+          } else {
+            console.log(`[Server] 🔄 Building app...`);
             await this.compileServerFunctions(compiler);
-          }
-
-          const isActionChange = compiler.modifiedFiles
-            ? Array.from(compiler.modifiedFiles).some((file) =>
-                file.includes("src/skill"),
-              )
-            : false;
-
-          if (isActionChange) {
-            console.log(`[Server] Detected changes in actions. Recompiling...`);
             this.pulseConfig = compileAppActionSkills(this.pulseConfig);
             this.saveConfig();
-          }
-        } else {
-          console.log(`[Server] 🔄 Building app...`);
-          await this.compileServerFunctions(compiler);
-          this.pulseConfig = compileAppActionSkills(this.pulseConfig);
-          this.saveConfig();
-          console.log(`[Server] ✅ Successfully built server.`);
+            console.log(`[Server] ✅ Successfully built server.`);
 
-          const funcs = discoverServerFunctions();
+            const funcs = discoverServerFunctions();
 
-          console.log(`\n🛜 Server functions:
+            console.log(`\n🛜 Server functions:
 ${Object.entries(funcs)
   .map(([name, file]) => {
     return `  - ${name.slice(2)} (from ${file})`;
   })
   .join("\n")}
 `);
-        }
-      });
+          }
+        },
+      );
 
       // After build finishes
       compiler.hooks.done.tap("ReloadMessagePlugin", () => {
@@ -185,11 +192,20 @@ ${Object.entries(funcs)
   private makeNodeFederationPlugin() {
     const funcs = discoverServerFunctions();
     const actions = discoverAppSkillActions();
+
+    // Resolve the runtime plugin path manually because NodeFederationPlugin's
+    // internal require.resolve fails due to rolldown virtual module shim.
+    const runtimePluginPath = path.resolve(
+      path.dirname(require.resolve("@module-federation/node/package.json")),
+      "dist/src/runtimePlugin.mjs",
+    );
+
     return new NodeFederationPlugin(
       {
         name: this.pulseConfig.id + "_server",
         remoteType: "script",
-        useRuntimePlugin: true,
+        useRuntimePlugin: false,
+        runtimePlugins: [runtimePluginPath],
         library: { type: "commonjs-module" },
         filename: "remoteEntry.js",
         exposes: {

--- a/npm-packages/react-api/CHANGELOG.md
+++ b/npm-packages/react-api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pulse-editor/react-api
 
+## 0.1.1-beta.87
+
+### Patch Changes
+
+- Update mf version
+- Updated dependencies
+  - @pulse-editor/shared-utils@0.1.1-beta.87
+
 ## 0.1.1-beta.86
 
 ### Patch Changes

--- a/npm-packages/react-api/package.json
+++ b/npm-packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulse-editor/react-api",
-  "version": "0.1.1-beta.86",
+  "version": "0.1.1-beta.87",
   "main": "dist/main.js",
   "files": [
     "dist"
@@ -44,12 +44,12 @@
     "vitest": "^4.1.2"
   },
   "peerDependencies": {
-    "@pulse-editor/shared-utils": "0.1.1-beta.86",
+    "@pulse-editor/shared-utils": "0.1.1-beta.87",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },
   "dependencies": {
-    "@module-federation/runtime": "^2.0.1",
+    "@module-federation/runtime": "^2.3.2",
     "use-debounce": "^10.1.0"
   }
 }

--- a/npm-packages/shared-utils/CHANGELOG.md
+++ b/npm-packages/shared-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pulse-editor/shared-utils
 
+## 0.1.1-beta.87
+
+### Patch Changes
+
+- Update mf version
+
 ## 0.1.1-beta.86
 
 ### Patch Changes

--- a/npm-packages/shared-utils/package.json
+++ b/npm-packages/shared-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulse-editor/shared-utils",
-    "version": "0.1.1-beta.86",
+    "version": "0.1.1-beta.87",
     "main": "dist/main.js",
     "files": [
         "dist"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8630,37 +8630,59 @@
       "license": "MIT"
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.0.1.tgz",
-      "integrity": "sha512-2bJF/ft+qL9L6Zvq2t/G9/f/0wFL73cM8/NJ04uyYz9BjIgvx28K5qu8/6+IwgEEKATG7vOhBBVj6wH3S+5ASA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.2.tgz",
+      "integrity": "sha512-Y8F6EG+shNY5mJ0yKcJh4t6HlMYEtqMvABDDmxWulLz/tSV859SL05I5eDR1EvK0jNhLbq8LFipFEToQLqF0AA==",
       "license": "MIT"
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.0.1.tgz",
-      "integrity": "sha512-UQ72P5Oo40dS6vdhHetwTtIsbGciEr+bjoYvDgh1WLPfFlTYd8zo9cLfqaf3juuPfV3cMVARAVPmh16lQYpUGA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.2.tgz",
+      "integrity": "sha512-JFSAbr0zBDmNF+wcqHw22CmZGuUZjTsa4qzm1+RUVi3blrnKeBj9Y2FppEOBwPc/FHUr4/MDijA/6GFE2cv7gQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.0.1",
-        "@module-federation/runtime-core": "2.0.1",
-        "@module-federation/sdk": "2.0.1"
+        "@module-federation/error-codes": "2.3.2",
+        "@module-federation/runtime-core": "2.3.2",
+        "@module-federation/sdk": "2.3.2"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.0.1.tgz",
-      "integrity": "sha512-gOuCPSHoQGUGwlxfSTMInFX+QvLxdEWegGGMiLdU5vqbXuva4E9M+kXBBO7/0MkcBPMmVs0wOJGm0XOLeV2f1Q==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.2.tgz",
+      "integrity": "sha512-o4Pfi21uADHtSl3/BHu/3ph5+069pDOXL8Lck12b+rxsHessbeZkNo+MOxwP+gXf8fFsT+f9spOmx+Y5gtyc2A==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.0.1",
-        "@module-federation/sdk": "2.0.1"
+        "@module-federation/error-codes": "2.3.2",
+        "@module-federation/sdk": "2.3.2"
       }
     },
-    "node_modules/@module-federation/sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.0.1.tgz",
-      "integrity": "sha512-32PwudojGjog51cwpTali7D6ud82oVgsyvOx9JjAzhvXBX96YI4mRsursuWcthDxmigJP9ZvUTXDuRUEDh1OQA==",
-      "license": "MIT"
+    "node_modules/@module-federation/runtime-core/node_modules/@module-federation/sdk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+      "integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/runtime/node_modules/@module-federation/sdk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.2.tgz",
+      "integrity": "sha512-EKiZpLnD2ogy7OcnuU+vkGO5vhh3J25PHwtEzgVGIAsMis3JHYPpY7L1Ue7i0zVrdmI23dVJPBtfGV/Pg7THPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -14079,12 +14101,6 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/wav-encoder": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/wav-encoder/-/wav-encoder-1.3.3.tgz",
@@ -15643,9 +15659,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -16747,15 +16763,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
-      "license": "MIT",
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
-      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.2",
@@ -18887,9 +18894,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -19801,16 +19808,16 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ibm-cloud-sdk-core": {
-      "version": "5.4.10",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.10.tgz",
-      "integrity": "sha512-A9CL/XQTNoyS2fkp1uKKcYC03CJwp7hIl4DQeyG9s9QLsuMwffOM2fIkORsYHhn5wmWeFUkjAmt2iTlb7Hv1Iw==",
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.11.tgz",
+      "integrity": "sha512-UYm6i3OCcQ1sBOVIJh0gcwCNltiGCf7QBCPaDtqCXuHIPbn8m9sKqVBqfrgFuQpenAak/Yv/450Vw+tC59XVIQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "1.14.0",
+        "axios": "1.15.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",
@@ -21735,23 +21742,20 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.5.tgz",
-      "integrity": "sha512-I5dmuLUh8GFkPQwa0J5YeGHB2efrvI/lOpM8PSfOUss+ZdfVyZJfRvlXXvlCXJ1T4EgKN+oXMHwdrpA+wrafJg==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.18.tgz",
+      "integrity": "sha512-3zuZUWffTHQ+73EAwnodADtf534VNEZUpXr9jC12qyG8/IQuJET7PRsCpTb9wX2lmBspakwLUpqpj3tNm/0bVA==",
       "license": "MIT",
       "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^5.6.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
+        "p-queue": "6.6.2",
+        "uuid": "10.0.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
         "@opentelemetry/exporter-trace-otlp-proto": "*",
         "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
+        "openai": "*",
+        "ws": ">=7"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -21765,19 +21769,10 @@
         },
         "openai": {
           "optional": true
+        },
+        "ws": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/langsmith/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/langsmith/node_modules/uuid": {
@@ -28407,12 +28402,6 @@
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
     },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT"
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -32259,9 +32248,9 @@
     },
     "npm-packages/react-api": {
       "name": "@pulse-editor/react-api",
-      "version": "0.1.1-beta.86",
+      "version": "0.1.1-beta.87",
       "dependencies": {
-        "@module-federation/runtime": "^2.0.1",
+        "@module-federation/runtime": "^2.3.2",
         "use-debounce": "^10.1.0"
       },
       "devDependencies": {
@@ -32290,7 +32279,7 @@
         "vitest": "^4.1.2"
       },
       "peerDependencies": {
-        "@pulse-editor/shared-utils": "0.1.1-beta.86",
+        "@pulse-editor/shared-utils": "0.1.1-beta.87",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       }
@@ -32629,7 +32618,7 @@
     },
     "npm-packages/shared-utils": {
       "name": "@pulse-editor/shared-utils",
-      "version": "0.1.1-beta.86",
+      "version": "0.1.1-beta.87",
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.0",
@@ -32696,7 +32685,7 @@
         "@langchain/openai": "^1.2.9",
         "@langchain/react": "^0.1.3",
         "@modelcontextprotocol/sdk": "^1.28.0",
-        "@module-federation/runtime": "2.0.1",
+        "@module-federation/runtime": "^2.3.2",
         "@pulse-editor/shared-utils": "^0.1.1-beta.80",
         "@ricky0123/vad-web": "0.0.30",
         "@toon-format/toon": "^2.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
       "@langchain/openai": "^1.2.9",
       "@langchain/react": "^0.1.3",
       "@modelcontextprotocol/sdk": "^1.28.0",
-      "@module-federation/runtime": "2.0.1",
+      "@module-federation/runtime": "^2.3.2",
       "@pulse-editor/shared-utils": "^0.1.1-beta.80",
       "@ricky0123/vad-web": "0.0.30",
       "@toon-format/toon": "^2.1.0",


### PR DESCRIPTION
…rocess

- Bump version to 0.1.26
- Update dependencies for @module-federation packages
- Modify pack script to clean dist directory before building

chore: release @pulse-editor/react-api version 0.1.1-beta.87

- Bump version to 0.1.1-beta.87
- Update peer dependency for @pulse-editor/shared-utils

chore: release @pulse-editor/shared-utils version 0.1.1-beta.87

- Bump version to 0.1.1-beta.87
- Update dependencies for module federation

chore: update package-lock.json for dependency updates

- Update @module-federation packages to version 2.3.2
- Update axios to version 1.15.0
- Update langsmith to version 0.5.18

chore: update web package to use latest @module-federation/runtime

- Change @module-federation/runtime version to ^2.3.2