### PR TITLE
docs(readme): add ClawHub download history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,3 +412,7 @@ Make sure to change back if using published versions.
 - Thanks to the developers and community of [Module Federation](https://module-federation.io/) for their groundbreaking work on micro-frontends.
 - Thanks to the developers and community of [Hero UI](https://www.heroui.com/) for their fantastic component library.
 - Thanks to the developers and community of [React Flow](https://reactflow.dev/) for their amazing node-based graph library.
+
+## Download History
+
+[![Download History](https://skill-history.com/chart/shellishack/pulse-editor.svg)](https://skill-history.com/shellishack/pulse-editor)


### PR DESCRIPTION
Hey! 👋

I'm Gavin — I built [skill-history.com](https://skill-history.com), a free tool that tracks ClawHub skill download history over time (think [star-history.com](https://star-history.com) but for agent skills).

I noticed your skill **Pulse Editor** has been getting traction — **2386 downloads** so far — so I set up a chart page for it:

👉 **https://skill-history.com/shellishack/pulse-editor**

This PR adds a small download history section to the bottom of your README with a live-updating chart that refreshes daily. Here's what it looks like:

![Preview](https://skill-history.com/chart/shellishack/pulse-editor.svg)

No setup, no tokens, no CI changes — just an SVG embed that auto-updates.

If you'd prefer a compact badge instead of the full chart, you can swap it for this:

![Downloads](https://skill-history.com/badge/shellishack/pulse-editor.svg)

`![Downloads](https://skill-history.com/badge/shellishack/pulse-editor.svg)`

The whole thing is open source: **[github.com/pineapple-farm/skill-history](https://github.com/pineapple-farm/skill-history)**

It's a brand new project and I'm shaping it based on what skill authors actually want. If you have any feedback, feature requests, or ideas:

- [Open an issue](https://github.com/pineapple-farm/skill-history/issues/new)
- Submit a PR
- Or just drop a comment here

Totally understand if this isn't your thing — feel free to close. But if it's useful, I'm excited to see it on your README!

Cheers,
Gavin
[Pineapple AI](https://pineappleai.com)